### PR TITLE
Back-end: Configure eslint

### DIFF
--- a/back-end/.eslintrc.js
+++ b/back-end/.eslintrc.js
@@ -15,5 +15,26 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
+    'import/prefer-default-export': 'off',
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
+    'no-console': 'off',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
+  },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
   },
 };


### PR DESCRIPTION
Add eslint rules to:
* Disable 'import/prefer-default-export' rule from airbnb eslint set
* Prevent clash with typescrypt's 'no-unused-vars'
* Resolve all used file extensions
 - [x] chore: add eslint configuration rules