### PR TITLE
Back-end: Simplify contracts

### DIFF
--- a/back-end/src/app/helpers/types/controller.interface.ts
+++ b/back-end/src/app/helpers/types/controller.interface.ts
@@ -1,11 +1,6 @@
-import {
-  ICreateInput, IDeleteInput, IUpdateInput, IUpdateStatusInput,
-} from './task.interface';
-
-export interface ControllerDTO<T> {
-  create(obj: ICreateInput): Promise<T>;
-  read(): Promise<Array<T>>;
-  updateStatus(obj: IUpdateStatusInput): Promise<T | null>;
-  update(obj: IUpdateInput): Promise<T | null>;
-  delete(obj: IDeleteInput): Promise<T | null>;
+export interface ControllerDTO<Output, CreateInput, UpdateInput, DeleteInput> {
+  create(obj: CreateInput): Promise<Output>;
+  read(): Promise<Array<Output>>;
+  update(obj: UpdateInput): Promise<Output | null>;
+  delete(obj: DeleteInput): Promise<Output | null>;
 }

--- a/back-end/src/app/helpers/types/model.interface.ts
+++ b/back-end/src/app/helpers/types/model.interface.ts
@@ -1,11 +1,6 @@
-import {
-  ICreateInput, IDeleteInput, IUpdateInput, IUpdateStatusInput,
-} from './task.interface';
-
-export interface ModelDTO<T> {
-  create(obj: ICreateInput): Promise<T>;
-  read(): Promise<Array<T>>;
-  updateStatus(obj: IUpdateStatusInput): Promise<T | null>;
-  update(obj: IUpdateInput): Promise<T | null>;
-  delete(obj: IDeleteInput): Promise<T | null>;
+export interface ModelDTO<Output, CreateInput, UpdateInput, DeleteInput> {
+  create(obj: CreateInput): Promise<Output>;
+  read(): Promise<Array<Output>>;
+  update(obj: UpdateInput): Promise<Output | null>;
+  delete(obj: DeleteInput): Promise<Output | null>;
 }

--- a/back-end/src/app/helpers/types/service.interface.ts
+++ b/back-end/src/app/helpers/types/service.interface.ts
@@ -1,11 +1,6 @@
-import {
-  ICreateInput, IDeleteInput, IUpdateInput, IUpdateStatusInput,
-} from './task.interface';
-
-export interface ServiceDTO<T> {
-  create(obj: ICreateInput): Promise<T>;
-  read(): Promise<Array<T>>;
-  updateStatus(obj: IUpdateStatusInput): Promise<T | null>;
-  update(obj: IUpdateInput): Promise<T | null>;
-  delete(obj: IDeleteInput): Promise<T | null>;
+export interface ServiceDTO<Output, CreateInput, UpdateInput, DeleteInput> {
+  create(obj: CreateInput): Promise<Output>;
+  read(): Promise<Array<Output>>;
+  update(obj: UpdateInput): Promise<Output | null>;
+  delete(obj: DeleteInput): Promise<Output | null>;
 }

--- a/back-end/src/app/helpers/types/task.interface.ts
+++ b/back-end/src/app/helpers/types/task.interface.ts
@@ -1,33 +1,15 @@
-import { ObjectId } from 'mongoose';
+export type TaskStatus = 'pendente' | 'andamento' | 'pronto';
 
-export type IStatus = 'pendente' | 'andamento' | 'pronto';
-
-export interface ICreateInput {
+export interface CreateTaskInput {
   name: string,
   description: string,
-  status: IStatus;
+  status: TaskStatus;
 }
 
-export interface IDeleteInput {
-  _id: ObjectId,
+export interface UpdateTaskInput extends CreateTaskInput{
+  _id: string,
 }
 
-export interface IUpdateInput {
-  _id: ObjectId,
-  name: string,
-  description: string,
-  status: IStatus;
-}
-
-export interface IUpdateStatusInput {
-  _id: ObjectId,
-  status: IStatus;
-}
-
-export interface ITask {
-  _id: ObjectId,
-  name: string,
-  description: string,
-  createdAt: Date,
-  status: IStatus;
+export interface DeleteTaskInput {
+  _id: string,
 }


### PR DESCRIPTION
- [x] refactor: simplify input interfaces and remove unused `ITask`
- [x] refactor: `ModelDTO` to use generic types for inputs and output
- [x] refactor: `ServiceDTO` to use generic types for inputs and output
- [x] refactor: `ControllerDTO` to use generic types for inputs and output